### PR TITLE
Some fixes for strings in Python3

### DIFF
--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,5 +1,5 @@
-text.usetex         : True
-text.latex.unicode : True 
+#text.usetex         : True
+#text.latex.unicode : True 
 text.latex.preamble :  \usepackage{txfonts}, \usepackage[T1]{fontenc}
 
 # Increase the tick-mark lengths (defaults are 4 and 2)

--- a/plot_BB_bounds.py
+++ b/plot_BB_bounds.py
@@ -59,7 +59,7 @@ for i in range(n_unique):
     for j in range(len(d['l_min'])):
         plt.plot([d['l_min'][j], d['l_max'][j]],
                  [d['BB_limit'][j], d['BB_limit'][j]],
-                 label=unique_list[i] if j == 0 else "", color=colors[i], lw=3)
+                 label=unique_list[i].decode('UTF-8') if j == 0 else "", color=colors[i], lw=3)
 
 names = ('l', 'TT', 'TE', 'EE', 'BB', 'TB', 'EB')
 formats = ('i4', 'f4', 'f4', 'f4', 'f4', 'f4', 'f4')

--- a/plot_BB_detections.py
+++ b/plot_BB_detections.py
@@ -66,7 +66,7 @@ experiments = [r'BICEP2+Keck', r'BICEP2+Keck/Planck', r'POLARBEAR', r'SPTpol']
 colors = ['b', 'c', 'g', 'r']
 
 for c, e in zip(colors, experiments):
-    d = data[data['experiment'] == e]
+    d = data[data['experiment'] == e.encode('UTF-8')]
 
     inds = (d['BB'] > 0)
     d = d[inds]
@@ -75,7 +75,7 @@ for c, e in zip(colors, experiments):
                  xerr=[d['l_center'] - d['l_min'], d['l_max'] - d['l_center']],
                  fmt='.', label=e, color=c, capthick=0, capsize=0)
 
-    d = data[data['experiment'] == e]
+    d = data[data['experiment'] == e.encode('UTF-8')]
     inds = (d['BB'] > 0)
     d = d[~inds]
     ulim = get_limit(d['BB'], d['sigma_BB_plus'], 0.95)


### PR DESCRIPTION
The two example Python scripts were crashing in Python3 because np.loadtxt would read in bytes strings